### PR TITLE
Allow fractional radii less than 1

### DIFF
--- a/Aura.js
+++ b/Aura.js
@@ -245,7 +245,7 @@ export class Aura
 
     shouldRender(flags)
     {
-        if (flags.radius < 1) {
+        if (flags.radius <= 0) {
             return false;
         }
 


### PR DESCRIPTION
Changes the radius check to verify that the radius is greater than 0
rather than greater than or equal to 1, which allows for auras that are
less than one grid space on systems that use unitless spaces such as
LANCER.
